### PR TITLE
Add license and clean up README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,26 +1,34 @@
-# Mandelbrot explorer
+# Mandelbrot Explorer
 
-## Description
-#### MSRV 1.77.2 nightly
-Desktop UI application for exploring the Mandelbrot set. Draggable and zoomable.
-Calculation is done on CPU with 64 bit precision.
-Written on Rust. Uses winit, wgpu, tokio and portable_simd.
-Multithreaded, uses SIMD.
-Preview drag and zoom done on GPU.
+A desktop application for exploring the Mandelbrot set. The project is written in Rust and uses **winit**, **wgpu**, **tokio**, and **portable\_simd** for high performance rendering.
 
-Uses nightly toolchain for SIMD support.
+## Features
 
-Runs pretty smooth on my Macbook Air M2 2022.
-The following single-threaded 2048x2048 image render with 1024 max iterations takes 135ms:
+- Interactive pan and zoom
+- CPU fractal calculations using 64‑bit precision
+- Multithreaded with SIMD acceleration
+- GPU based preview during navigation
 
-![bench.png](/doc/bench.png)
+## Requirements
 
+The project targets the Rust nightly toolchain (tested with nightly 1.77.2) for SIMD support.
 
-## Additional images
-https://youtu.be/W6jAF17scfc
+## Benchmark
+
+Rendering a single‑threaded 2048×2048 image with 1024 iterations takes about 135 ms on a MacBook Air M2 2022.
+
+![Benchmark](doc/bench.png)
+
+## Demo
 
 [![Youtube demo](https://img.youtube.com/vi/W6jAF17scfc/0.jpg)](https://www.youtube.com/watch?v=W6jAF17scfc)
 
-![screenshot1](/doc/Screenshot%202023-08-21%20at%206.23.35%20PM.png)
+Additional screenshots can be found in the `doc/` directory:
 
-![scrennshot2](/doc/Screenshot%202024-05-18%20at%208.45.35%E2%80%AFAM.png)
+![Screenshot 1](doc/Screenshot%202023-08-21%20at%206.23.35%20PM.png)
+
+![Screenshot 2](doc/Screenshot%202024-05-18%20at%208.45.35%E2%80%AFAM.png)
+
+## License
+
+This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary
- add MIT license
- rewrite README with clearer instructions and demo links

## Testing
- `cargo test` *(fails: could not download nightly toolchain)*