### PR TITLE
Use free list in buffer pool

### DIFF
--- a/src/buffer_pool.rs
+++ b/src/buffer_pool.rs
@@ -1,43 +1,82 @@
 use parking_lot::Mutex;
-use std::sync::Arc;
+use std::sync::{atomic::{AtomicUsize, Ordering}, Arc, Weak};
 
 #[derive(Debug)]
 pub struct BufferPool {
+    inner: Arc<BufferPoolInner>,
+}
+
+#[derive(Debug)]
+struct BufferPoolInner {
     buf_size: usize,
-    buffers: Vec<Arc<Mutex<Vec<u8>>>>,
-    total_allocated: usize,
+    available: Mutex<Vec<Vec<u8>>>,
+    total_allocated: AtomicUsize,
+}
+
+#[derive(Debug)]
+pub struct BufferHandle {
+    data: Mutex<Vec<u8>>,
+    pool: Weak<BufferPoolInner>,
+}
+
+impl BufferHandle {
+    pub fn lock(&self) -> parking_lot::MutexGuard<'_, Vec<u8>> {
+        self.data.lock()
+    }
+}
+
+impl Drop for BufferHandle {
+    fn drop(&mut self) {
+        if let Some(pool) = self.pool.upgrade() {
+            let mut buf = self.data.lock();
+            let mut avail = pool.available.lock();
+            avail.push(std::mem::take(&mut *buf));
+        }
+    }
 }
 
 impl BufferPool {
     pub fn new(buf_size: usize, reserved_count: usize) -> Self {
-        let buffers = (0..reserved_count)
-            .map(|_| Arc::new(Mutex::new(vec![0u8; buf_size])))
-            .collect();
-
-        Self {
+        let inner = Arc::new(BufferPoolInner {
             buf_size,
-            buffers,
-            total_allocated: reserved_count,
+            available: Mutex::new(Vec::new()),
+            total_allocated: AtomicUsize::new(0),
+        });
+
+        {
+            let mut avail = inner.available.lock();
+            for _ in 0..reserved_count {
+                avail.push(vec![0u8; buf_size]);
+                inner.total_allocated.fetch_add(1, Ordering::Relaxed);
+            }
         }
+
+        Self { inner }
     }
 
-    pub fn take(&mut self) -> Arc<Mutex<Vec<u8>>> {
-        if let Some(buf) = self.buffers.iter().find(|buf| Arc::strong_count(buf) == 1) {
-            buf.clone()
-        } else {
-            self.total_allocated += 1;
-            println!("Total allocated buffers: {}", self.total_allocated);
+    pub fn take(&self) -> Arc<BufferHandle> {
+        let vec = self
+            .inner
+            .available
+            .lock()
+            .pop()
+            .unwrap_or_else(|| {
+                let new_total = self.inner.total_allocated.fetch_add(1, Ordering::Relaxed) + 1;
+                if cfg!(debug_assertions) {
+                    println!("Total allocated buffers: {}", new_total);
+                }
+                vec![0u8; self.inner.buf_size]
+            });
 
-            self.buffers
-                .push(Arc::new(Mutex::new(vec![0u8; self.buf_size])));
-            self.buffers.last().unwrap().clone()
-        }
+        Arc::new(BufferHandle {
+            data: Mutex::new(vec),
+            pool: Arc::downgrade(&self.inner),
+        })
     }
 
     pub(crate) fn taken_buffer_count(&self) -> u32 {
-        self.buffers
-            .iter()
-            .filter(|buf| Arc::strong_count(buf) > 1)
-            .count() as u32
+        let allocated = self.inner.total_allocated.load(Ordering::Relaxed);
+        let available = self.inner.available.lock().len();
+        (allocated - available) as u32
     }
 }

--- a/src/mandel_texture.rs
+++ b/src/mandel_texture.rs
@@ -11,7 +11,7 @@ use tokio::sync::Semaphore;
 use tokio::task::JoinHandle;
 use wgpu::util::DeviceExt;
 
-use crate::buffer_pool::BufferPool;
+use crate::buffer_pool::{BufferHandle, BufferPool};
 use crate::mandelbrot_simd::{mandelbrot_simd, Pixel, MAX_ITER};
 use crate::math::{DRect, URect};
 use crate::render_pods::{PushConst, ScreenRect};
@@ -29,7 +29,7 @@ pub enum TileState {
         cancel_token: Arc<AtomicBool>,
     },
     WaitForUpload {
-        buffer: Arc<Mutex<Vec<u8>>>,
+        buffer: Arc<BufferHandle>,
     },
 }
 


### PR DESCRIPTION
## Summary
- maintain a freelist in `BufferPool`
- return `BufferHandle` that puts buffers back on drop
- gate allocation log behind `debug_assertions`
- adapt mandel texture code to new handle type

## Testing
- `cargo check` *(fails: could not download toolchain)*
- `cargo fmt --all` *(fails: could not download toolchain)*